### PR TITLE
Fix GitHub Actions configuration

### DIFF
--- a/dbbackup/tests/testapp/urls.py
+++ b/dbbackup/tests/testapp/urls.py
@@ -1,11 +1,5 @@
-try:
-    from django.conf.urls import patterns, include, url
-    urlpatterns = patterns(
-        '',
-        # url(r'^admin/', include(admin.site.urls)),
-    )
-except ImportError:
-    from django.conf.urls import include, url
-    urlpatterns = (
-        # url(r'^admin/', include(admin.site.urls)),
-    )
+from django.urls import include, re_path
+
+urlpatterns = (
+    # url(r'^admin/', include(admin.site.urls)),
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,24 +1,15 @@
 [tox]
-envlist = py{3.6,3.7,3.8,nightly}-django2.2,py{3.6,3.7,3.8,3.9,3.10,nightly}-django{3.2,4.0,master},lint,docs,functional
+envlist = py{36,37,38,39}-django22,py{36,37,38,39,310}-django{32,40,master},lint,docs,functional
 
 [testenv]
 passenv = *
 setenv =
     PYTHONDONTWRITEBYTECODE=1
-basepython =
-    py3.6: python3.6
-    py3.7: python3.7
-    py3.8: python3.8
-    py3.9: python3.9
-    py3.10: python3.10
-    pypypy: pypy
-    pypypy3: pypy3
-    pynightly: python
 deps =
     -rrequirements-tests.txt
-    django2.2: Django>=2.2,<2.3
-    django3.2: Django>=3.2,<3.3
-    django4.0: Django>=4.0,<4.1
+    django22: Django>=2.2,<2.3
+    django32: Django>=3.2,<3.3
+    django40: Django>=4.0,<4.1
     djangomaster: https://github.com/django/django/archive/master.zip
 commands = {posargs:coverage run runtests.py}
 


### PR DESCRIPTION
# Bug Fix

## Description

The GitHub Actions `tox` configuration was misconfigured such that no unit tests were actually running.

This was due in part to non-standard `tox` configuration conventions `py3.6` vs `py36`. This PR uses the standard Python versioning that is available by default in `tox`.

- https://tox.wiki/en/latest/config.html#tox-environments

Regression in

- 2d7151f5c2615517e6686576e1d53e0c89cfd549
- #408

Also remove deprecated import that caused failure under Python 3.10

## Why should this be added

Currently no unit tests are running on CI
