### PR TITLE
Include package data to fix docs and pypi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     python_requires=">=3.6",
     install_requires=get_requirements(),
     tests_require=get_test_requirements(),
+    include_package_data=True,
     license="BSD",
     url="https://github.com/jazzband/django-dbbackup",
     keywords=[


### PR DESCRIPTION
Builds now require a VERSION file, therefore, package data is required alongside the installation.