### PR TITLE
fix GPG manual anchor and typo

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -61,7 +61,7 @@ Default: ``'%Y-%m-%d-%H%M%S'``
 DBBACKUP_HOSTNAME
 ~~~~~~~~~~~~~~~~~
 
-Used to identify a backup by a server name in their file name..
+Used to identify a backup by a server name in the file name.
 
 Default: ``socket.gethostname()``
 
@@ -120,7 +120,7 @@ Requirements:
 
 -  Install the python package python-gnupg:
    ``pip install python-gnupg``.
--  You need a GPG key. (`GPG manual`)
+-  You need a GPG key. (`GPG manual`_)
 -  Set the setting ``DBBACKUP_GPG_RECIPIENT`` to the name of the GPG key.
 
 .. _`GPG manual`: https://www.gnupg.org/gph/en/manual/c14.html


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

documentation update

Please include a summary of the change and which issue is fixed.

fix the gpg manual link so that the anchor url is displayed, and fix small typo in same file

## Why should this be added

readability

## Checklist

- [ n/a] Documentation has been added or amended for this feature / update
