### PR TITLE
support for prometheus wrapped dbs

### DIFF
--- a/dbbackup/db/base.py
+++ b/dbbackup/db/base.py
@@ -33,7 +33,7 @@ CONNECTOR_MAPPING = {
     "django_prometheus.db.backends.postgresql": "dbbackup.db.postgresql.PgDumpBinaryConnector",
     "django_prometheus.db.backends.sqlite3": "dbbackup.db.sqlite.SqliteConnector",
     "django_prometheus.db.backends.mysql": "dbbackup.db.mysql.MysqlDumpConnector",
-    "django_prometheus.db.backends.postgis": "dbbackup.db.postgresql.PgDumpGisConnector"
+    "django_prometheus.db.backends.postgis": "dbbackup.db.postgresql.PgDumpGisConnector",
 }
 
 if settings.CUSTOM_CONNECTOR_MAPPING:

--- a/dbbackup/db/base.py
+++ b/dbbackup/db/base.py
@@ -30,6 +30,10 @@ CONNECTOR_MAPPING = {
     "django.contrib.gis.db.backends.mysql": "dbbackup.db.mysql.MysqlDumpConnector",
     "django.contrib.gis.db.backends.oracle": None,
     "django.contrib.gis.db.backends.spatialite": "dbbackup.db.sqlite.SqliteConnector",
+    "django_prometheus.db.backends.postgresql": "dbbackup.db.postgresql.PgDumpBinaryConnector",
+    "django_prometheus.db.backends.sqlite3": "dbbackup.db.sqlite.SqliteConnector",
+    "django_prometheus.db.backends.mysql": "dbbackup.db.mysql.MysqlDumpConnector",
+    "django_prometheus.db.backends.postgis": "dbbackup.db.postgresql.PgDumpGisConnector"
 }
 
 if settings.CUSTOM_CONNECTOR_MAPPING:

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -46,12 +46,12 @@ Absolute path to a connector class by default is:
 
 All supported built-in connectors are described in more detail below.
 
-Following database wrappers from `django-prometheus https://github.com/korfuri/django-prometheus`_ module are supported:
+Following database wrappers from ``django-prometheus`` module are supported:
 
-- `django_prometheus.db.backends.postgresql` for `dbbackup.db.postgresql.PgDumpBinaryConnector`
-- `django_prometheus.db.backends.sqlite3` for `dbbackup.db.sqlite.SqliteConnector`
-- `django_prometheus.db.backends.mysql` for `dbbackup.db.mysql.MysqlDumpConnector`
-- `django_prometheus.db.backends.postgis` for `dbbackup.db.postgresql.PgDumpGisConnector`
+- ``django_prometheus.db.backends.postgresql`` for ``dbbackup.db.postgresql.PgDumpBinaryConnector``
+- ``django_prometheus.db.backends.sqlite3`` for ``dbbackup.db.sqlite.SqliteConnector``
+- ``django_prometheus.db.backends.mysql`` for ``dbbackup.db.mysql.MysqlDumpConnector``
+- ``django_prometheus.db.backends.postgis`` for ``dbbackup.db.postgresql.PgDumpGisConnector``
 
 EXCLUDE
 ~~~~~~~

--- a/docs/databases.rst
+++ b/docs/databases.rst
@@ -46,6 +46,13 @@ Absolute path to a connector class by default is:
 
 All supported built-in connectors are described in more detail below.
 
+Following database wrappers from `django-prometheus https://github.com/korfuri/django-prometheus`_ module are supported:
+
+- `django_prometheus.db.backends.postgresql` for `dbbackup.db.postgresql.PgDumpBinaryConnector`
+- `django_prometheus.db.backends.sqlite3` for `dbbackup.db.sqlite.SqliteConnector`
+- `django_prometheus.db.backends.mysql` for `dbbackup.db.mysql.MysqlDumpConnector`
+- `django_prometheus.db.backends.postgis` for `dbbackup.db.postgresql.PgDumpGisConnector`
+
 EXCLUDE
 ~~~~~~~
 


### PR DESCRIPTION
# Support for prometheus wrapped dbs

## Description
If someone uses django-prometheus in her project, she is going to use django_prometheus.db.backends.<...> as value in DATABASES as ENGINE key. Unfortunately it breaks dbbackup command:  
```
Traceback (most recent call last):
  File "/home/ubuntu/reps/jitlearning/webpage_django/manage.py", line 22, in <module>
    main()
  File "/home/ubuntu/reps/jitlearning/webpage_django/manage.py", line 18, in main
    execute_from_command_line(sys.argv)
  File "/home/ubuntu/miniconda/envs/vocabuserver/lib/python3.10/site-packages/django/core/management/__init__.py", line 446, in execute_from_command_line
    utility.execute()
  File "/home/ubuntu/miniconda/envs/vocabuserver/lib/python3.10/site-packages/django/core/management/__init__.py", line 440, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/ubuntu/miniconda/envs/vocabuserver/lib/python3.10/site-packages/django/core/management/base.py", line 414, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/home/ubuntu/miniconda/envs/vocabuserver/lib/python3.10/site-packages/django/core/management/base.py", line 460, in execute
    output = self.handle(*args, **options)
  File "/home/ubuntu/miniconda/envs/vocabuserver/lib/python3.10/site-packages/dbbackup/utils.py", line 120, in wrapper
    func(*args, **kwargs)
  File "/home/ubuntu/miniconda/envs/vocabuserver/lib/python3.10/site-packages/dbbackup/management/commands/dbbackup.py", line 86, in handle
    self.connector = get_connector(database_key)
  File "/home/ubuntu/miniconda/envs/vocabuserver/lib/python3.10/site-packages/dbbackup/db/base.py", line 50, in get_connector
    connector_path = connector_settings.get("CONNECTOR", CONNECTOR_MAPPING[engine])
KeyError: 'django_prometheus.db.backends.postgresql'
```
All supported prometheus wrappers can be found in https://github.com/korfuri/django-prometheus/tree/master/django_prometheus/db/backends .

Easy solution is just to add all prometheus wrapper names in the `dbbackup/db/base.py`
Worked for my `django_prometheus.db.backends.postgresql` key. Didn't test the rest but looks straightforward.

This is my first contribution to open source, please tell me if I should've done something else.