### PR TITLE
Fixed TypeError when performing SQLite dbbackup

### DIFF
--- a/dbbackup/db/sqlite.py
+++ b/dbbackup/db/sqlite.py
@@ -39,7 +39,7 @@ class SqliteConnector(BaseDBConnector):
                 sql = sql.replace("\n)", ")")
                 fileobj.write(f"{sql};\n".encode())
             else:
-                fileobj.write(f"{sql};\n")
+                fileobj.write(bytes(f"{sql};\n", encoding='utf8'))
             table_name_ident = table_name.replace('"', '""')
             res = cursor.execute(f'PRAGMA table_info("{table_name_ident}")')
             column_names = [str(table_info[1]) for table_info in res.fetchall()]

--- a/dbbackup/db/sqlite.py
+++ b/dbbackup/db/sqlite.py
@@ -39,7 +39,7 @@ class SqliteConnector(BaseDBConnector):
                 sql = sql.replace("\n)", ")")
                 fileobj.write(f"{sql};\n".encode())
             else:
-                fileobj.write(bytes(f"{sql};\n", encoding='utf8'))
+                fileobj.write(bytes(f"{sql};\n", encoding="utf8"))
             table_name_ident = table_name.replace('"', '""')
             res = cursor.execute(f'PRAGMA table_info("{table_name_ident}")')
             column_names = [str(table_info[1]) for table_info in res.fetchall()]


### PR DESCRIPTION
# Fixed TypeError when performing SQLite dbbackup

## Description

Running `python manage.py dbbackup` with an SQLite database returned `TypeError: a bytes-like object is required, not 'str'`.

```
(example-venv-3.10.5) sid@Sids-MacBook-Pro example % python manage.py dbbackup
TypeError: a bytes-like object is required, not 'str'
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/dbbackup/utils.py", line 120, in wrapper
    func(*args, **kwargs)
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/dbbackup/management/commands/dbbackup.py", line 93, in handle
    self._save_new_backup(database)
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/dbbackup/management/commands/dbbackup.py", line 106, in _save_new_backup
    outputfile = self.connector.create_dump()
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/dbbackup/db/sqlite.py", line 67, in create_dump
    self._write_dump(dump_file)
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/dbbackup/db/sqlite.py", line 42, in _write_dump
    fileobj.write(f"{sql};\n")
  File "/Users/sid/.pyenv/versions/3.10.5/lib/python3.10/tempfile.py", line 771, in write
    rv = file.write(s)

Traceback (most recent call last):
  File "/Users/sid/pycharm-workspace/Example/example/manage.py", line 14, in <module>
    execute_from_command_line(sys.argv)
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/django/core/management/__init__.py", line 446, in execute_from_command_line
    utility.execute()
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/django/core/management/__init__.py", line 440, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/django/core/management/base.py", line 414, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/django/core/management/base.py", line 460, in execute
    output = self.handle(*args, **options)
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/dbbackup/utils.py", line 120, in wrapper
    func(*args, **kwargs)
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/dbbackup/management/commands/dbbackup.py", line 93, in handle
    self._save_new_backup(database)
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/dbbackup/management/commands/dbbackup.py", line 106, in _save_new_backup
    outputfile = self.connector.create_dump()
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/dbbackup/db/sqlite.py", line 67, in create_dump
    self._write_dump(dump_file)
  File "/Users/sid/.pyenv/versions/3.10.5/envs/example-venv-3.10.5/lib/python3.10/site-packages/dbbackup/db/sqlite.py", line 42, in _write_dump
    fileobj.write(f"{sql};\n")
  File "/Users/sid/.pyenv/versions/3.10.5/lib/python3.10/tempfile.py", line 771, in write
    rv = file.write(s)
TypeError: a bytes-like object is required, not 'str'
```
## Fix

By changing line 42 of the `db/sqlite.py` to write a UTF-8 encoded byte-type object, the backup is carried out without any errors.