### PR TITLE
Backup of SQLite fail if there are Virtual Tables (e.g. FTS tables).

### DIFF
--- a/dbbackup/tests/test_connectors/test_sqlite.py
+++ b/dbbackup/tests/test_connectors/test_sqlite.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 
+from django.db import connection
 from django.test import TestCase
 from mock import mock_open, patch
 
@@ -31,6 +32,14 @@ class SqliteConnectorTest(TestCase):
         connector = SqliteConnector()
         dump = connector.create_dump()
         connector.restore_dump(dump)
+
+    def test_create_dump_with_virtual_tables(self):
+        with connection.cursor() as c:
+            c.execute("CREATE VIRTUAL TABLE lookup USING fts5(field)")
+
+        connector = SqliteConnector()
+        dump = connector.create_dump()
+        self.assertTrue(dump.read())
 
 
 @patch("dbbackup.db.sqlite.open", mock_open(read_data=b"foo"), create=True)


### PR DESCRIPTION
# Type of PR (feature, enhancement, bug fix, etc.)

Bug fix

## Description

Backup failed if the database included Virtual Tables (e.g. tables created for FTS).

Not sure if I should ammend line 36 instead (fix to CREATE VIRTUAL TABLE IF NOT EXISTS).

Related to https://github.com/jazzband/django-dbbackup/pull/457, but I can't be sure #457 was also caused by virtual tables.

## Why should this be added

App is currently broken for almost any Wagtail, as long as it includes "search" and is indexed.

## Checklist

- [NOT NEEDED ] Documentation has been added or amended for this feature / update
