### PR TITLE
Closes #460: python-gnupg version increase breaks unencrypt_file func…

### DIFF
--- a/dbbackup/utils.py
+++ b/dbbackup/utils.py
@@ -228,7 +228,9 @@ def unencrypt_file(inputfile, filename, passphrase=None):
             inputfile.seek(0)
             g = gnupg.GPG()
             result = g.decrypt_file(
-                file=inputfile, passphrase=get_passphrase(), output=temp_filename
+                fileobj_or_path=inputfile,
+                passphrase=get_passphrase(),
+                output=temp_filename,
             )
             if not result:
                 raise DecryptionError("Decryption failed; status: %s" % result.status)

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -119,7 +119,7 @@ using GPG. ::
 Requirements:
 
 -  Install the python package python-gnupg:
-   ``pip install python-gnupg``.
+   ``pip install python-gnupg>=0.5.0``.
 -  You need a GPG key. (`GPG manual`_)
 -  Set the setting ``DBBACKUP_GPG_RECIPIENT`` to the name of the GPG key.
 

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -6,7 +6,7 @@ pep8
 psycopg2
 pylint
 python-dotenv
-python-gnupg
+python-gnupg>=0.5.0
 pytz
 testfixtures
 tox


### PR DESCRIPTION

# bugfix

## Description

Set minimum version for python-gnupg, update docs, update utils.unencrypt_file function to use python-gnupg >= 0.5.0 decrypt_file arguments

Fixes #460 

## Why should this be added

Will allow tests to pass again and re-enable the encrypt/decrypt backup features for new installs.

## Checklist

- [x] Documentation has been added or amended for this feature / update
