### PR TITLE
Fix restore fail after editing filename

### DIFF
--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -64,7 +64,9 @@ class Command(BaseDbBackupCommand):
             self.passphrase = options.get("passphrase")
             self.interactive = options.get("interactive")
             self.input_database_name = options.get("database")
-            self.database_name, self.database = self._get_database(self.input_database_name)
+            self.database_name, self.database = self._get_database(
+                self.input_database_name
+            )
             self.storage = get_storage()
             self._restore_backup()
         except StorageError as err:

--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -63,15 +63,15 @@ class Command(BaseDbBackupCommand):
             self.uncompress = options.get("uncompress")
             self.passphrase = options.get("passphrase")
             self.interactive = options.get("interactive")
-            self.database_name, self.database = self._get_database(options)
+            self.input_database_name = options.get("database")
+            self.database_name, self.database = self._get_database(self.input_database_name)
             self.storage = get_storage()
             self._restore_backup()
         except StorageError as err:
             raise CommandError(err) from err
 
-    def _get_database(self, options):
+    def _get_database(self, database_name: str):
         """Get the database to restore."""
-        database_name = options.get("database")
         if not database_name:
             if len(settings.DATABASES) > 1:
                 errmsg = (
@@ -87,7 +87,7 @@ class Command(BaseDbBackupCommand):
     def _restore_backup(self):
         """Restore the specified database."""
         input_filename, input_file = self._get_backup_file(
-            database=self.database_name, servername=self.servername
+            database=self.input_database_name, servername=self.servername
         )
         self.logger.info(
             "Restoring backup for database '%s' and server '%s'",

--- a/dbbackup/tests/commands/test_dbrestore.py
+++ b/dbbackup/tests/commands/test_dbrestore.py
@@ -43,6 +43,7 @@ class DbrestoreCommandRestoreBackupTest(TestCase):
         self.command.interactive = True
         self.command.storage = get_storage()
         self.command.servername = HOSTNAME
+        self.command.input_database_name = None
         self.command.database_name = "default"
         self.command.connector = get_connector("default")
         HANDLED_FILES.clean()
@@ -107,12 +108,12 @@ class DbrestoreCommandGetDatabaseTest(TestCase):
         self.command = DbrestoreCommand()
 
     def test_give_db_name(self):
-        name, db = self.command._get_database({"database": "default"})
+        name, db = self.command._get_database("default")
         self.assertEqual(name, "default")
         self.assertEqual(db, settings.DATABASES["default"])
 
     def test_no_given_db(self):
-        name, db = self.command._get_database({})
+        name, db = self.command._get_database(None)
         self.assertEqual(name, "default")
         self.assertEqual(db, settings.DATABASES["default"])
 
@@ -143,6 +144,7 @@ class DbMongoRestoreCommandRestoreBackupTest(TestCase):
         self.command.storage = get_storage()
         self.command.connector = MongoDumpConnector()
         self.command.database_name = "mongo"
+        self.command.input_database_name = None
         self.command.servername = HOSTNAME
         HANDLED_FILES.clean()
         add_private_gpg()


### PR DESCRIPTION
# Bug fix 
## Description

When issuing restore command - keep track of database name input from user to use it as a lookup string for getting a most recent backup file (instead of using the default database name when the user did not provide any database name - which resulted into a lookup error for backup file as the backup file does not have the database name in its filename structure). 

Fixes #434