### PR TITLE
reintroduced `inputfile.seek(0)` to utils.uncompress_file

### DIFF
--- a/dbbackup/tests/functional/test_commands.py
+++ b/dbbackup/tests/functional/test_commands.py
@@ -102,6 +102,8 @@ class DbRestoreCommandTest(TestCase):
         self.instance.delete()
         # Restore
         execute_from_command_line(["", "dbrestore", "--uncompress"])
+        restored = models.CharModel.objects.all().exists()
+        self.assertTrue(restored)
 
     def test_no_backup_available(self, *args):
         with self.assertRaises(SystemExit):

--- a/dbbackup/tests/functional/test_commands.py
+++ b/dbbackup/tests/functional/test_commands.py
@@ -131,6 +131,16 @@ class DbRestoreCommandTest(TestCase):
         # Restore
         execute_from_command_line(["", "dbrestore", "--database", "default"])
 
+    @patch("dbbackup.utils.getpass", return_value=None)
+    def test_compressed_and_encrypted(self, *args):
+        # Create backup
+        execute_from_command_line(["", "dbbackup", "--compress", "--encrypt"])
+        self.instance.delete()
+        # Restore
+        execute_from_command_line(["", "dbrestore", "--uncompress", "--decrypt"])
+        restored = models.CharModel.objects.all().exists()
+        self.assertTrue(restored)
+
 
 class MediaBackupCommandTest(TestCase):
     def setUp(self):

--- a/dbbackup/utils.py
+++ b/dbbackup/utils.py
@@ -282,6 +282,7 @@ def uncompress_file(inputfile, filename):
     """
     zipfile = gzip.GzipFile(fileobj=inputfile, mode="rb")
     try:
+        inputfile.seek(0)
         outputfile = create_spooled_temporary_file(fileobj=zipfile)
     finally:
         zipfile.close()

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* reintroduced inputfile.seek(0) to utils.uncompress_file `#503`_
+
+
 4.0.0b0 (2021-12-19)
 --------------------
 


### PR DESCRIPTION
## Description

This is a very small fix for #292.
I think this issue got introduced way back by #189.
In there line 244 `inputfile.seek(0)` got removed, which seems to cause this issue.
Simply reintroducing this line makes the uncompressing work again.

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
