### PR TITLE
remove usage of old mock

### DIFF
--- a/dbbackup/tests/commands/test_base.py
+++ b/dbbackup/tests/commands/test_base.py
@@ -5,10 +5,10 @@ Tests for base command class.
 import logging
 import os
 from io import BytesIO
+from unittest.mock import patch
 
 from django.core.files import File
 from django.test import TestCase
-from mock import patch
 
 from dbbackup.management.commands._base import BaseDbBackupCommand
 from dbbackup.storage import get_storage

--- a/dbbackup/tests/commands/test_listbackups.py
+++ b/dbbackup/tests/commands/test_listbackups.py
@@ -1,8 +1,8 @@
 from io import StringIO
+from unittest.mock import patch
 
 from django.core.management import execute_from_command_line
 from django.test import TestCase
-from mock import patch
 
 from dbbackup.management.commands.listbackups import Command as ListbackupsCommand
 from dbbackup.storage import get_storage

--- a/dbbackup/tests/functional/test_commands.py
+++ b/dbbackup/tests/functional/test_commands.py
@@ -1,10 +1,10 @@
 import os
 import tempfile
+from unittest.mock import patch
 
 from django.conf import settings
 from django.core.management import execute_from_command_line
 from django.test import TransactionTestCase as TestCase
-from mock import patch
 
 from dbbackup.tests.testapp import models
 from dbbackup.tests.utils import (

--- a/dbbackup/tests/test_checks.py
+++ b/dbbackup/tests/test_checks.py
@@ -1,5 +1,6 @@
+from unittest.mock import patch
+
 from django.test import TestCase
-from mock import patch
 
 try:
     from dbbackup import checks

--- a/dbbackup/tests/test_connectors/test_mongodb.py
+++ b/dbbackup/tests/test_connectors/test_mongodb.py
@@ -1,7 +1,7 @@
 from io import BytesIO
+from unittest.mock import patch
 
 from django.test import TestCase
-from mock import patch
 
 from dbbackup.db.mongodb import MongoDumpConnector
 

--- a/dbbackup/tests/test_connectors/test_mysql.py
+++ b/dbbackup/tests/test_connectors/test_mysql.py
@@ -1,7 +1,7 @@
 from io import BytesIO
+from unittest.mock import patch
 
 from django.test import TestCase
-from mock import patch
 
 from dbbackup.db.mysql import MysqlDumpConnector
 

--- a/dbbackup/tests/test_connectors/test_sqlite.py
+++ b/dbbackup/tests/test_connectors/test_sqlite.py
@@ -1,8 +1,8 @@
 from io import BytesIO
+from unittest.mock import mock_open, patch
 
 from django.db import connection
 from django.test import TestCase
-from mock import mock_open, patch
 
 from dbbackup.db.sqlite import SqliteConnector, SqliteCPConnector
 from dbbackup.tests.testapp.models import CharModel

--- a/dbbackup/tests/test_log.py
+++ b/dbbackup/tests/test_log.py
@@ -1,9 +1,9 @@
 import logging
+from unittest.mock import patch
 
 import django
 from django.core import mail
 from django.test import TestCase
-from mock import patch
 from testfixtures import log_capture
 
 from dbbackup import log

--- a/dbbackup/tests/test_storage.py
+++ b/dbbackup/tests/test_storage.py
@@ -1,5 +1,6 @@
+from unittest.mock import patch
+
 from django.test import TestCase
-from mock import patch
 
 from dbbackup import utils
 from dbbackup.storage import Storage, get_storage

--- a/dbbackup/tests/test_utils.py
+++ b/dbbackup/tests/test_utils.py
@@ -2,12 +2,12 @@ import os
 import tempfile
 from datetime import datetime
 from io import StringIO
+from unittest.mock import patch
 
 import django
 import pytz
 from django.core import mail
 from django.test import TestCase
-from mock import patch
 
 from dbbackup import settings, utils
 from dbbackup.tests.utils import (

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,7 +1,6 @@
 coverage
 django-storages
 flake8
-mock
 pep8
 psycopg2
 pylint


### PR DESCRIPTION
Hi,

This project actualy already uses unittest.mock in some places:
https://github.com/jazzband/django-dbbackup/blob/87952dcbffb91c3a8472581b3172dc684b0b405f/dbbackup/tests/commands/test_dbbackup.py#L6
https://github.com/jazzband/django-dbbackup/blob/87952dcbffb91c3a8472581b3172dc684b0b405f/dbbackup/tests/commands/test_dbrestore.py#L7


https://github.com/testing-cabal/mock

`mock is now part of the Python standard library, available as [unittest.mock](https://docs.python.org/dev/library/unittest.mock.html) in Python 3.3 onwards.`
