### PR TITLE
fixes for Django 5.1, add support for new STORAGES setting

### DIFF
--- a/dbbackup/management/commands/mediabackup.py
+++ b/dbbackup/management/commands/mediabackup.py
@@ -5,11 +5,10 @@ Save media files.
 import os
 import tarfile
 
-from django.core.files.storage import get_storage_class
 from django.core.management.base import CommandError
 
 from ... import utils
-from ...storage import StorageError, get_storage
+from ...storage import StorageError, get_storage, get_storage_class
 from ._base import BaseDbBackupCommand, make_option
 
 

--- a/dbbackup/management/commands/mediarestore.py
+++ b/dbbackup/management/commands/mediarestore.py
@@ -4,10 +4,8 @@ Restore media files.
 
 import tarfile
 
-from django.core.files.storage import get_storage_class
-
 from ... import utils
-from ...storage import get_storage
+from ...storage import get_storage, get_storage_class
 from ._base import BaseDbBackupCommand, make_option
 
 

--- a/dbbackup/settings.py
+++ b/dbbackup/settings.py
@@ -35,10 +35,23 @@ MEDIA_FILENAME_TEMPLATE = getattr(
 GPG_ALWAYS_TRUST = getattr(settings, "DBBACKUP_GPG_ALWAYS_TRUST", False)
 GPG_RECIPIENT = GPG_ALWAYS_TRUST = getattr(settings, "DBBACKUP_GPG_RECIPIENT", None)
 
-STORAGE = getattr(
-    settings, "DBBACKUP_STORAGE", "django.core.files.storage.FileSystemStorage"
-)
+STORAGE = getattr(settings, "DBBACKUP_STORAGE", None)
 STORAGE_OPTIONS = getattr(settings, "DBBACKUP_STORAGE_OPTIONS", {})
+# https://docs.djangoproject.com/en/5.1/ref/settings/#std-setting-STORAGES
+STORAGES_DBBACKUP_ALIAS = 'dbbackup'
+DJANGO_STORAGES = getattr(settings, "STORAGES", {})
+django_dbbackup_storage = DJANGO_STORAGES.get(STORAGES_DBBACKUP_ALIAS, {})
+
+if not STORAGE:
+    STORAGE = (
+        django_dbbackup_storage.get("BACKEND")
+        or "django.core.files.storage.FileSystemStorage"
+    )
+if not STORAGE_OPTIONS:
+    STORAGE_OPTIONS = (
+        django_dbbackup_storage.get("OPTIONS")
+        or STORAGE_OPTIONS
+    )
 
 CONNECTORS = getattr(settings, "DBBACKUP_CONNECTORS", {})
 

--- a/dbbackup/settings.py
+++ b/dbbackup/settings.py
@@ -38,7 +38,7 @@ GPG_RECIPIENT = GPG_ALWAYS_TRUST = getattr(settings, "DBBACKUP_GPG_RECIPIENT", N
 STORAGE = getattr(settings, "DBBACKUP_STORAGE", None)
 STORAGE_OPTIONS = getattr(settings, "DBBACKUP_STORAGE_OPTIONS", {})
 # https://docs.djangoproject.com/en/5.1/ref/settings/#std-setting-STORAGES
-STORAGES_DBBACKUP_ALIAS = 'dbbackup'
+STORAGES_DBBACKUP_ALIAS = "dbbackup"
 DJANGO_STORAGES = getattr(settings, "STORAGES", {})
 django_dbbackup_storage = DJANGO_STORAGES.get(STORAGES_DBBACKUP_ALIAS, {})
 
@@ -48,10 +48,7 @@ if not STORAGE:
         or "django.core.files.storage.FileSystemStorage"
     )
 if not STORAGE_OPTIONS:
-    STORAGE_OPTIONS = (
-        django_dbbackup_storage.get("OPTIONS")
-        or STORAGE_OPTIONS
-    )
+    STORAGE_OPTIONS = django_dbbackup_storage.get("OPTIONS") or STORAGE_OPTIONS
 
 CONNECTORS = getattr(settings, "DBBACKUP_CONNECTORS", {})
 

--- a/dbbackup/storage.py
+++ b/dbbackup/storage.py
@@ -5,7 +5,7 @@ Utils for handle files.
 import logging
 
 from django.core.exceptions import ImproperlyConfigured
-from django.core.files.storage import get_storage_class
+from django.core.files.storage import DefaultStorage
 
 from . import settings, utils
 
@@ -285,3 +285,29 @@ class Storage:
             if keep_filter(filename):
                 continue
             self.delete_file(filename)
+
+
+def get_storage_class(path: str | None = None):
+    """
+    Return the configured storage class.
+    
+    :param path: Path in Python dot style to module containing the storage
+                    class. If empty settings.DBBACKUP_STORAGE will be used.
+    :type path: str
+        
+    :returns: Storage class
+    :rtype: :class:`django.core.files.storage.Storage`
+    """
+    from django.utils.module_loading import import_string
+    
+    if path:
+        # this is a workaround to keep compatibility with Django >= 5.1 (django.core.files.storage.get_storage_class is removed)
+        return import_string(path)
+    
+    # TODO: Use django.core.files.storage.storages dict on Django >= 5.1
+    # This would require a change in the dbbackup settings to make use of the the new STORAGES dict settings
+    # like so: STORAGES = { "dbbackup": { "BACKEND": "django.core.files.storage.FileSystemStorage", "OPTIONS": {...} } }
+    # and then returning storages['dbbackup'] here
+    
+    return DefaultStorage
+    

--- a/dbbackup/storage.py
+++ b/dbbackup/storage.py
@@ -289,23 +289,25 @@ class Storage:
 def get_storage_class(path=None):
     """
     Return the configured storage class.
-    
+
     :param path: Path in Python dot style to module containing the storage
                     class. If empty, the default storage class will be used.
     :type path: str or None
-        
+
     :returns: Storage class
     :rtype: :class:`django.core.files.storage.Storage`
     """
     from django.utils.module_loading import import_string
-    
+
     if path:
         # this is a workaround to keep compatibility with Django >= 5.1 (django.core.files.storage.get_storage_class is removed)
         return import_string(path)
-    
+
     try:
         from django.core.files.storage import DefaultStorage
+
         return DefaultStorage
     except Exception:
         from django.core.files.storage import get_storage_class
+
         return get_storage_class()

--- a/dbbackup/storage.py
+++ b/dbbackup/storage.py
@@ -5,7 +5,6 @@ Utils for handle files.
 import logging
 
 from django.core.exceptions import ImproperlyConfigured
-from django.core.files.storage import DefaultStorage
 
 from . import settings, utils
 
@@ -287,13 +286,13 @@ class Storage:
             self.delete_file(filename)
 
 
-def get_storage_class(path: str | None = None):
+def get_storage_class(path=None):
     """
     Return the configured storage class.
     
     :param path: Path in Python dot style to module containing the storage
-                    class. If empty settings.DBBACKUP_STORAGE will be used.
-    :type path: str
+                    class. If empty, the default storage class will be used.
+    :type path: str or None
         
     :returns: Storage class
     :rtype: :class:`django.core.files.storage.Storage`
@@ -304,10 +303,9 @@ def get_storage_class(path: str | None = None):
         # this is a workaround to keep compatibility with Django >= 5.1 (django.core.files.storage.get_storage_class is removed)
         return import_string(path)
     
-    # TODO: Use django.core.files.storage.storages dict on Django >= 5.1
-    # This would require a change in the dbbackup settings to make use of the the new STORAGES dict settings
-    # like so: STORAGES = { "dbbackup": { "BACKEND": "django.core.files.storage.FileSystemStorage", "OPTIONS": {...} } }
-    # and then returning storages['dbbackup'] here
-    
-    return DefaultStorage
-    
+    try:
+        from django.core.files.storage import DefaultStorage
+        return DefaultStorage
+    except Exception:
+        from django.core.files.storage import get_storage_class
+        return get_storage_class()

--- a/dbbackup/tests/commands/test_mediabackup.py
+++ b/dbbackup/tests/commands/test_mediabackup.py
@@ -6,11 +6,10 @@ import contextlib
 import os
 import tempfile
 
-from django.core.files.storage import get_storage_class
 from django.test import TestCase
 
 from dbbackup.management.commands.mediabackup import Command as DbbackupCommand
-from dbbackup.storage import get_storage
+from dbbackup.storage import get_storage, get_storage_class
 from dbbackup.tests.utils import DEV_NULL, HANDLED_FILES, add_public_gpg
 
 

--- a/dbbackup/tests/settings.py
+++ b/dbbackup/tests/settings.py
@@ -72,7 +72,7 @@ STORAGES = {
     "dbbackup": {
         "BACKEND": DBBACKUP_STORAGE,
         "OPTIONS": DBBACKUP_STORAGE_OPTIONS,
-    }
+    },
 }
 
 LOGGING = {

--- a/dbbackup/tests/settings.py
+++ b/dbbackup/tests/settings.py
@@ -63,6 +63,24 @@ DBBACKUP_STORAGE_OPTIONS = dict(
     ]
 )
 
+# For testing the new storages setting introduced in Django 4.2
+# STORAGES = {
+#     "default": {
+#         "BACKEND": "django.core.files.storage.FileSystemStorage",
+#         "OPTIONS": {},
+#     },
+#     "dbbackup": {
+#         "BACKEND": os.environ.get("STORAGE", "dbbackup.tests.utils.FakeStorage"),
+#         "OPTIONS": dict(
+#             [
+#                 keyvalue.split("=")
+#                 for keyvalue in os.environ.get("STORAGE_OPTIONS", "").split(",")
+#                 if keyvalue
+#             ]
+#         )
+#     }
+# }
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,

--- a/dbbackup/tests/settings.py
+++ b/dbbackup/tests/settings.py
@@ -64,22 +64,16 @@ DBBACKUP_STORAGE_OPTIONS = dict(
 )
 
 # For testing the new storages setting introduced in Django 4.2
-# STORAGES = {
-#     "default": {
-#         "BACKEND": "django.core.files.storage.FileSystemStorage",
-#         "OPTIONS": {},
-#     },
-#     "dbbackup": {
-#         "BACKEND": os.environ.get("STORAGE", "dbbackup.tests.utils.FakeStorage"),
-#         "OPTIONS": dict(
-#             [
-#                 keyvalue.split("=")
-#                 for keyvalue in os.environ.get("STORAGE_OPTIONS", "").split(",")
-#                 if keyvalue
-#             ]
-#         )
-#     }
-# }
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+        "OPTIONS": {},
+    },
+    "dbbackup": {
+        "BACKEND": DBBACKUP_STORAGE,
+        "OPTIONS": DBBACKUP_STORAGE_OPTIONS,
+    }
+}
 
 LOGGING = {
     "version": 1,

--- a/dbbackup/tests/test_storage.py
+++ b/dbbackup/tests/test_storage.py
@@ -29,21 +29,23 @@ class Get_StorageTest(TestCase):
             # TODO: Remove "django.core.files.storage" case when dropping support for Django < 4.2.
             ("django.core.files.storage", "django.core.files.storage.filesystem"),
         )
-        
+
     def test_get_storage_class(self):
         storage_class = get_storage_class(DEFAULT_STORAGE_PATH)
-        self.assertIn(storage_class.__module__,
+        self.assertIn(
+            storage_class.__module__,
             ("django.core.files.storage", "django.core.files.storage.filesystem"),
         )
         self.assertIn(storage_class.__name__, ("FileSystemStorage", "DefaultStorage"))
-        
+
         storage_class = get_storage_class("dbbackup.tests.utils.FakeStorage")
         self.assertEqual(storage_class.__module__, "dbbackup.tests.utils")
         self.assertEqual(storage_class.__name__, "FakeStorage")
-                
+
     def test_default_storage_class(self):
         storage_class = get_storage_class()
-        self.assertIn(storage_class.__module__,
+        self.assertIn(
+            storage_class.__module__,
             ("django.core.files.storage", "django.core.files.storage.filesystem"),
         )
         self.assertIn(storage_class.__name__, ("FileSystemStorage", "DefaultStorage"))
@@ -54,24 +56,28 @@ class Get_StorageTest(TestCase):
 
     def test_storages_settings(self):
         from .settings import STORAGES
+
         self.assertIsInstance(STORAGES, dict)
-        self.assertEqual(STORAGES["dbbackup"]["BACKEND"], "dbbackup.tests.utils.FakeStorage")
-        
+        self.assertEqual(
+            STORAGES["dbbackup"]["BACKEND"], "dbbackup.tests.utils.FakeStorage"
+        )
+
         from dbbackup.settings import DJANGO_STORAGES, STORAGE
+
         self.assertIsInstance(DJANGO_STORAGES, dict)
         self.assertEqual(DJANGO_STORAGES, STORAGES)
         self.assertEqual(STORAGES["dbbackup"]["BACKEND"], STORAGE)
-        
+
         storage = get_storage()
         self.assertEqual(storage.storage.__class__.__module__, "dbbackup.tests.utils")
         self.assertEqual(storage.storage.__class__.__name__, "FakeStorage")
-        
+
     def test_storages_settings_options(self):
-        from .settings import STORAGES
         from dbbackup.settings import STORAGE_OPTIONS
+
+        from .settings import STORAGES
+
         self.assertEqual(STORAGES["dbbackup"]["OPTIONS"], STORAGE_OPTIONS)
-        
-        
 
 
 class StorageTest(TestCase):

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,8 @@ Unreleased
 * Add PostgreSQL Schema support by @angryfoxx in https://github.com/jazzband/django-dbbackup/pull/507
 * Fix restore of database from S3 storage by reintroducing inputfile.seek(0) to utils.uncompress_file
 * Fix bug where dbbackup management command would not respect settings.py:DBBACKUP_DATABASES
+* Remove usage of deprecated 'get_storage_class' function in newer Django versions
+* Add support for new STORAGES (Django 4.2+) setting under the 'dbbackup' alias
 
 4.1.0 (2024-01-14)
 ------------------

--- a/docs/storage.rst
+++ b/docs/storage.rst
@@ -7,11 +7,31 @@ mainly based on Django Storage API and extends its possibilities.
 
 You can choose your backup storage backend by setting ``settings.DBBACKUP_STORAGE``,
 it must be the full path of a storage class. For example:
-``django.core.files.storage.FileSystemStorage`` to use file system storage.
+``django.core.files.storage.FileSystemStorage`` to use file system storage. 
 Below, we'll list some of the available solutions and their options.
+
 
 The storage's option are gathered in ``settings.DBBACKUP_STORAGE_OPTIONS`` which
 is a dictionary of keywords representing how to configure it.
+
+Since Django 4.2 there is a new way to configure storages using the STORAGES setting. E.g.:::
+
+    STORAGES = {
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+            "OPTIONS": {
+            ...your_options_here
+            },
+        },
+        "staticfiles": {
+            ...
+        },
+    }
+
+instead of the previous DEFAULT_FILE_STORAGE and STATICFILES_STORAGE settings. 
+If ``settings.DBBACKUP_STORAGE`` is not set, django-dbbackup will look for the ``dbbackup`` key in the ``STORAGES`` dictionary setting.
+Otherwise, the default storage will be used.
+
 
 .. warning::
 
@@ -43,6 +63,16 @@ settings below. ::
     DBBACKUP_STORAGE = 'django.core.files.storage.FileSystemStorage'
     DBBACKUP_STORAGE_OPTIONS = {'location': '/my/backup/dir/'}
 
+Alternatively, starting from Django 4.2, you can use the STORAGES setting: ::
+
+    STORAGES = {
+        "dbbackup": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+            "OPTIONS": {
+                "location": "/my/backup/dir/",
+            },
+        },
+    }
 
 Available settings
 ~~~~~~~~~~~~~~~~~~

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,312}-django{32,42,50,master},lint,docs,functional
+envlist = py{37,38,39,310,311,312}-django{32,42,50,51,master},lint,docs,functional
 
 [testenv]
 passenv = *
@@ -10,6 +10,7 @@ deps =
     django32: django>=3.2,<3.3
     django42: django>=4.2,<4.3
     django50: django>=5.0,<5.1
+    django51: django>=5.1,<5.2
     djangomaster: https://github.com/django/django/archive/master.zip
 commands = {posargs:coverage run runtests.py}
 
@@ -19,9 +20,9 @@ python =
     3.7: py37-django{32},functional
     3.8: py38-django{32,42},functional
     3.9: py39-django{32,42},functional
-    3.10: py310-django{32,42,50},functional
-    3.11: py311-django{42,50},functional
-    3.12: py312-django{42,50},functional
+    3.10: py310-django{32,42,50,51},functional
+    3.11: py311-django{42,50,51},functional
+    3.12: py312-django{42,50,51},functional
 
 [testenv:lint]
 basepython = python


### PR DESCRIPTION
## Description

- Add custom `get_storage_class` to replace the removed method in Django 5.1 and avoid breaking changes
- Add support for new STORAGES setting using the 'dbbackup' alias.

Example:

```
STORAGES = {
    "default": {
        "BACKEND": "django.core.files.storage.FileSystemStorage",
        "OPTIONS": ...,
    },
    "dbbackup": {
        "BACKEND": "django.core.files.storage.FileSystemStorage",
        "OPTIONS": {
            "location": "/my/backup/dir/",
        },
    },
}
```

The previous DBBACKUP_STORAGE and DBBACKUP_STORAGE_OPTIONS are still valid and take precedence.

Fixes https://github.com/jazzband/django-dbbackup/issues/522 and should also fix https://github.com/jazzband/django-dbbackup/issues/523.

Please double check if I missed anything. 

What confused me a bit was that for the DB Storage this package always uses the configured DBBACKUP_STORAGE, while the mediabackup storage always uses the default django storage. I kept this behavior to not break anything. 

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
