### PR TITLE
Fix legacy GH link in docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -24,7 +24,7 @@ that are at least present when using PyPi repositories.
 
 ::
 
-    pip install -e git+https://github.com/mjs7231/django-dbbackup.git#egg=django-dbbackup
+    pip install -e git+https://github.com/jazzband/django-dbbackup.git#egg=django-dbbackup
 
 
 Add it in your project


### PR DESCRIPTION
## Description

Found an old GitHub link that is no longer valid. This PR updates it to the new dbbackup link.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
