### PR TITLE
Adds django_s3_sqlite to CONNECTOR_MAPPING dict.

### DIFF
--- a/dbbackup/db/base.py
+++ b/dbbackup/db/base.py
@@ -35,6 +35,7 @@ CONNECTOR_MAPPING = {
     "django_prometheus.db.backends.sqlite3": "dbbackup.db.sqlite.SqliteConnector",
     "django_prometheus.db.backends.mysql": "dbbackup.db.mysql.MysqlDumpConnector",
     "django_prometheus.db.backends.postgis": "dbbackup.db.postgresql.PgDumpGisConnector",
+    "django_s3_sqlite": "dbbackup.db.sqlite.SqliteConnector",
 }
 
 if settings.CUSTOM_CONNECTOR_MAPPING:


### PR DESCRIPTION
## Description

Adds support for django_s3_sqlite database backend

- Fix https://github.com/jazzband/django-dbbackup/issues/538
