### PR TITLE
Don't break socket connections for postgres

### DIFF
--- a/dbbackup/db/postgresql.py
+++ b/dbbackup/db/postgresql.py
@@ -8,10 +8,10 @@ logger = logging.getLogger("dbbackup.command")
 
 
 def create_postgres_uri(self):
-    host = self.settings.get("HOST") or "localhost"
-    dbname = self.settings.get("NAME") or ""
+    host = self.settings.get("HOST", "localhost")
+    dbname = self.settings.get("NAME", "")
     user = quote(self.settings.get("USER") or "")
-    password = self.settings.get("PASSWORD") or ""
+    password = self.settings.get("PASSWORD", "")
     password = f":{quote(password)}" if password else ""
     if not user:
         password = ""

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 Unreleased
 ----------
 
-* Nothing (yet)!
+* Empty string as HOST for postgres unix domain socket connection is now supported.
 
 4.2.1 (2024-08-23)
 ----------


### PR DESCRIPTION
Also, use dict.get() for default values.

## Description

Fixes #490.

#521 prevents users from setting host to an empty string for socket connections. It also contradicts the Django docs referenced in #520 which clearly state that empty HOST for Postgres means local socket connections.

## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
