### PR TITLE
Support Python 3.13, add Django 5.1 trove classifier, and fix Python 3.7 CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
     build:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-22.04
         strategy:
             matrix:
                 python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-22.04
         strategy:
             matrix:
-                python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
+                python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
         steps:
             - uses: actions/checkout@v4
             - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
         "Framework :: Django :: 3.2",
         "Framework :: Django :: 4.2",
         "Framework :: Django :: 5.0",
+        "Framework :: Django :: 5.1",
         "Intended Audience :: Developers",
         "Intended Audience :: System Administrators",
         "License :: OSI Approved :: BSD License",

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Database",
         "Topic :: System :: Archiving",
         "Topic :: System :: Archiving :: Backup",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{37,38,39,310,311,312}-django{32,42,50,51,master},lint,docs,functional
+envlist = py{37,38,39,310,311,312,313}-django{32,42,50,51,master},lint,docs,functional
 
 [testenv]
 passenv = *
@@ -23,6 +23,7 @@ python =
     3.10: py310-django{32,42,50,51},functional
     3.11: py311-django{42,50,51},functional
     3.12: py312-django{42,50,51},functional
+    3.13: py313-django{51},functional
 
 [testenv:lint]
 basepython = python


### PR DESCRIPTION
## Description

- Add support for Python 3.13
- Add Django 5.1 trove classifier to signal support, following
  - #524
- Pin to an older Ubuntu version in CI to allow testing under Python 3.7, which is required until @jezdez transfers this project out of jazzband so that we can admin the required CI checks and drop 3.7.
  - https://github.com/jazzband/help/issues/336