### PR TITLE
fix: --no-drop behaviour restored and working

### DIFF
--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -140,5 +140,5 @@ class Command(BaseDbBackupCommand):
         self.connector = get_connector(self.database_name)
         if self.schemas:
             self.connector.schemas = self.schemas
-        self.connector.restore_dump(input_file)
         self.connector.drop = not self.no_drop
+        self.connector.restore_dump(input_file)


### PR DESCRIPTION
## Description

Reverse order of two lines to restore the working behaviour of adding --no-drop to the CLI.

Prior to this no-drop was always set to false.

fixes https://github.com/jazzband/django-dbbackup/issues/545


## Checklist

Please update this checklist as you complete each item:

-   [ ] Tests have been developed for bug fixes or new functionality.
-   [ ] The changelog has been updated, if necessary.
-   [ ] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
