### PR TITLE
feat: allow passing of postgres options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,11 @@ different server. You may also specify an explicit local file to backup from.
     -p PASSPHRASE, --passphrase=PASSPHRASE
                           Passphrase for decrypt file
     -z, --uncompress      Uncompress gzip data before restoring
-
+    -n SCHEMA, --schema SCHEMA
+                        Specify schema(s) to restore. Can be used multiple times.
+    -r, --no-drop         Don't clean (drop) the database. This only works with mongodb and postgresql.
+    --pg-options PG_OPTIONS
+                        Additional pg_restore options, e.g. '--if-exists --no-owner'. Use quotes.
 
 mediabackup
 -----------

--- a/dbbackup/db/base.py
+++ b/dbbackup/db/base.py
@@ -128,7 +128,6 @@ class BaseCommandDBConnector(BaseDBConnector):
     use_parent_env = True
     env = {}
     dump_env = {}
-    # use the environment from the shell that invoked dbbackup
     restore_env = {}
 
     def run_command(self, command, stdin=None, env=None):

--- a/dbbackup/db/base.py
+++ b/dbbackup/db/base.py
@@ -128,6 +128,7 @@ class BaseCommandDBConnector(BaseDBConnector):
     use_parent_env = True
     env = {}
     dump_env = {}
+    # use the environment from the shell that invoked dbbackup
     restore_env = {}
 
     def run_command(self, command, stdin=None, env=None):

--- a/dbbackup/db/postgresql.py
+++ b/dbbackup/db/postgresql.py
@@ -145,51 +145,49 @@ class PgDumpBinaryConnector(PgDumpConnector):
 
         # Flatten optional values
         if self.restore_prefix:
-            cmd += (
+            cmd.extend (
                 self.restore_prefix
                 if isinstance(self.restore_prefix, list)
                 else [self.restore_prefix]
             )
 
         if self.restore_cmd:
-            cmd += (
+            cmd.extend (
                 self.restore_cmd
                 if isinstance(self.restore_cmd, list)
                 else [self.restore_cmd]
             )
 
         if self.pg_options:
-            cmd += (
+            cmd.extend (
                 self.pg_options
                 if isinstance(self.pg_options, list)
                 else [self.pg_options]
             )
 
-        cmd.append(dbname)
+        cmd.extend([dbname])
 
         if self.single_transaction:
-            cmd.append("--single-transaction")
+            cmd.extend(["--single-transaction"])
 
         if self.drop:
-            cmd.append("--clean")
+            cmd.extend(["--clean"])
 
         if self.schemas:
             for schema in self.schemas:
-                cmd += ["-n", schema]
+                cmd.extend(["-n", schema])
 
         if self.if_exists:
-            cmd.append("--if-exists")
+            cmd.extend(["--if-exists"])
 
         if self.restore_suffix:
-            cmd += (
+            cmd.extend(
                 self.restore_suffix
                 if isinstance(self.restore_suffix, list)
                 else [self.restore_suffix]
             )
 
         cmd_str = " ".join(cmd)
-        # TODO: ready to more safely execute with subprocess.run, rather than breaking apart a string with shlex.
-
         stdout, _ = self.run_command(cmd_str, stdin=dump, env=self.dump_env)
 
         return stdout

--- a/dbbackup/db/postgresql.py
+++ b/dbbackup/db/postgresql.py
@@ -113,6 +113,7 @@ class PgDumpBinaryConnector(PgDumpConnector):
     single_transaction = True
     drop = True
     if_exists = False
+    pg_options = None
 
     def _create_dump(self):
         cmd = f"{self.dump_cmd} "
@@ -129,22 +130,51 @@ class PgDumpBinaryConnector(PgDumpConnector):
         stdout, _ = self.run_command(cmd, env=self.dump_env)
         return stdout
 
-    def _restore_dump(self, dump):
+
+    def _restore_dump(self, dump: str):
+        """
+        Restore a PostgreSQL dump using subprocess with argument list.
+
+        Assumes that restore_prefix, restore_cmd, pg_options, and restore_suffix
+        are either None, strings (single args), or lists of strings.
+
+        Builds the command as a list.
+        """
+
         dbname = create_postgres_uri(self)
-        cmd = f"{self.restore_cmd} {dbname}"
+        cmd = []
+
+        # Flatten optional values
+        if self.restore_prefix:
+            cmd += self.restore_prefix if isinstance(self.restore_prefix, list) else [self.restore_prefix]
+
+        if self.restore_cmd:
+            cmd += self.restore_cmd if isinstance(self.restore_cmd, list) else [self.restore_cmd]
+
+        if self.pg_options:
+            cmd += self.pg_options if isinstance(self.pg_options, list) else [self.pg_options]
+
+        cmd.append(dbname)
 
         if self.single_transaction:
-            cmd += " --single-transaction"
+            cmd.append("--single-transaction")
 
         if self.drop:
-            cmd += " --clean"
+            cmd.append("--clean")
 
         if self.schemas:
-            cmd += " -n " + " -n ".join(self.schemas)
+            for schema in self.schemas:
+                cmd += ["-n", schema]
 
         if self.if_exists:
-            cmd += " --if-exists"
+            cmd.append("--if-exists")
 
-        cmd = f"{self.restore_prefix} {cmd} {self.restore_suffix}"
-        stdout, stderr = self.run_command(cmd, stdin=dump, env=self.restore_env)
-        return stdout, stderr
+        if self.restore_suffix:
+            cmd += self.restore_suffix if isinstance(self.restore_suffix, list) else [self.restore_suffix]
+
+        cmd_str = " ".join(cmd)
+        # TODO: ready to more safely execute with subprocess.run, rather than breaking apart a string with shlex.
+
+        stdout, _ = self.run_command(cmd_str, stdin=dump, env=self.dump_env)
+
+        return stdout

--- a/dbbackup/db/postgresql.py
+++ b/dbbackup/db/postgresql.py
@@ -145,21 +145,21 @@ class PgDumpBinaryConnector(PgDumpConnector):
 
         # Flatten optional values
         if self.restore_prefix:
-            cmd.extend (
+            cmd.extend(
                 self.restore_prefix
                 if isinstance(self.restore_prefix, list)
                 else [self.restore_prefix]
             )
 
         if self.restore_cmd:
-            cmd.extend (
+            cmd.extend(
                 self.restore_cmd
                 if isinstance(self.restore_cmd, list)
                 else [self.restore_cmd]
             )
 
         if self.pg_options:
-            cmd.extend (
+            cmd.extend(
                 self.pg_options
                 if isinstance(self.pg_options, list)
                 else [self.pg_options]

--- a/dbbackup/db/postgresql.py
+++ b/dbbackup/db/postgresql.py
@@ -130,7 +130,6 @@ class PgDumpBinaryConnector(PgDumpConnector):
         stdout, _ = self.run_command(cmd, env=self.dump_env)
         return stdout
 
-
     def _restore_dump(self, dump: str):
         """
         Restore a PostgreSQL dump using subprocess with argument list.
@@ -146,13 +145,25 @@ class PgDumpBinaryConnector(PgDumpConnector):
 
         # Flatten optional values
         if self.restore_prefix:
-            cmd += self.restore_prefix if isinstance(self.restore_prefix, list) else [self.restore_prefix]
+            cmd += (
+                self.restore_prefix
+                if isinstance(self.restore_prefix, list)
+                else [self.restore_prefix]
+            )
 
         if self.restore_cmd:
-            cmd += self.restore_cmd if isinstance(self.restore_cmd, list) else [self.restore_cmd]
+            cmd += (
+                self.restore_cmd
+                if isinstance(self.restore_cmd, list)
+                else [self.restore_cmd]
+            )
 
         if self.pg_options:
-            cmd += self.pg_options if isinstance(self.pg_options, list) else [self.pg_options]
+            cmd += (
+                self.pg_options
+                if isinstance(self.pg_options, list)
+                else [self.pg_options]
+            )
 
         cmd.append(dbname)
 
@@ -170,7 +181,11 @@ class PgDumpBinaryConnector(PgDumpConnector):
             cmd.append("--if-exists")
 
         if self.restore_suffix:
-            cmd += self.restore_suffix if isinstance(self.restore_suffix, list) else [self.restore_suffix]
+            cmd += (
+                self.restore_suffix
+                if isinstance(self.restore_suffix, list)
+                else [self.restore_suffix]
+            )
 
         cmd_str = " ".join(cmd)
         # TODO: ready to more safely execute with subprocess.run, rather than breaking apart a string with shlex.

--- a/dbbackup/management/commands/dbrestore.py
+++ b/dbbackup/management/commands/dbrestore.py
@@ -16,6 +16,7 @@ class Command(BaseDbBackupCommand):
     help = "Restore a database backup from storage, encrypted and/or compressed."
     content_type = "db"
     no_drop = False
+    pg_options = ""
 
     option_list = BaseDbBackupCommand.option_list + (
         make_option("-d", "--database", help="Database to restore"),
@@ -60,6 +61,12 @@ class Command(BaseDbBackupCommand):
             default=False,
             help="Don't clean (drop) the database. This only works with mongodb and postgresql.",
         ),
+        make_option(
+            "--pg-options",
+            dest="pg_options",
+            default="",
+            help="Additional pg_restore options, e.g. '--if-exists --no-owner'. Use quotes.",
+        ),
     )
 
     def handle(self, *args, **options):
@@ -83,6 +90,7 @@ class Command(BaseDbBackupCommand):
             )
             self.storage = get_storage()
             self.no_drop = options.get("no_drop")
+            self.pg_options = options.get("pg_options", "")
             self.schemas = options.get("schema")
             self._restore_backup()
         except StorageError as err:
@@ -141,4 +149,5 @@ class Command(BaseDbBackupCommand):
         if self.schemas:
             self.connector.schemas = self.schemas
         self.connector.drop = not self.no_drop
+        self.connector.pg_options = self.pg_options
         self.connector.restore_dump(input_file)

--- a/dbbackup/tests/test_connectors/test_postgresql.py
+++ b/dbbackup/tests/test_connectors/test_postgresql.py
@@ -1,6 +1,5 @@
 from io import BytesIO
 from unittest.mock import patch
-
 from django.test import TestCase
 
 from dbbackup.db.postgresql import (
@@ -222,6 +221,13 @@ class PgDumpBinaryConnectorTest(TestCase):
         self.connector.if_exists = True
         self.connector.restore_dump(dump)
         self.assertIn(" --if-exists", mock_run_command.call_args[0][0])
+
+    def test_pg_options(self,mock_run_command):
+        dump = self.connector.create_dump()
+        self.connector.pg_options = "--foo"
+        self.connector.restore_dump(dump)
+        cmd_args = mock_run_command.call_args[0][0]
+        self.assertIn("--foo", cmd_args)
 
     @patch(
         "dbbackup.db.postgresql.PgDumpBinaryConnector.run_command",

--- a/dbbackup/tests/test_connectors/test_postgresql.py
+++ b/dbbackup/tests/test_connectors/test_postgresql.py
@@ -230,6 +230,20 @@ class PgDumpBinaryConnectorTest(TestCase):
         cmd_args = mock_run_command.call_args[0][0]
         self.assertIn("--foo", cmd_args)
 
+    def test_restore_prefix(self, mock_run_command):
+        dump = self.connector.create_dump()
+        self.connector.restore_prefix = "foo"
+        self.connector.restore_dump(dump)
+        cmd_args = mock_run_command.call_args[0][0]
+        self.assertTrue( cmd_args.startswith('foo '))
+
+    def test_restore_suffix(self, mock_run_command):
+        dump = self.connector.create_dump()
+        self.connector.restore_suffix = "foo"
+        self.connector.restore_dump(dump)
+        cmd_args = mock_run_command.call_args[0][0]
+        self.assertTrue( cmd_args.endswith(' foo'))
+
     @patch(
         "dbbackup.db.postgresql.PgDumpBinaryConnector.run_command",
         return_value=(BytesIO(), BytesIO()),

--- a/dbbackup/tests/test_connectors/test_postgresql.py
+++ b/dbbackup/tests/test_connectors/test_postgresql.py
@@ -235,14 +235,14 @@ class PgDumpBinaryConnectorTest(TestCase):
         self.connector.restore_prefix = "foo"
         self.connector.restore_dump(dump)
         cmd_args = mock_run_command.call_args[0][0]
-        self.assertTrue( cmd_args.startswith('foo '))
+        self.assertTrue(cmd_args.startswith("foo "))
 
     def test_restore_suffix(self, mock_run_command):
         dump = self.connector.create_dump()
         self.connector.restore_suffix = "foo"
         self.connector.restore_dump(dump)
         cmd_args = mock_run_command.call_args[0][0]
-        self.assertTrue( cmd_args.endswith(' foo'))
+        self.assertTrue(cmd_args.endswith(" foo"))
 
     @patch(
         "dbbackup.db.postgresql.PgDumpBinaryConnector.run_command",

--- a/dbbackup/tests/test_connectors/test_postgresql.py
+++ b/dbbackup/tests/test_connectors/test_postgresql.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 from unittest.mock import patch
+
 from django.test import TestCase
 
 from dbbackup.db.postgresql import (
@@ -222,7 +223,7 @@ class PgDumpBinaryConnectorTest(TestCase):
         self.connector.restore_dump(dump)
         self.assertIn(" --if-exists", mock_run_command.call_args[0][0])
 
-    def test_pg_options(self,mock_run_command):
+    def test_pg_options(self, mock_run_command):
         dump = self.connector.create_dump()
         self.connector.pg_options = "--foo"
         self.connector.restore_dump(dump)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 Unreleased
 ----------
 
+* Add generic `--pg-options` to pass custom options to postgres.
 * Add option `--if-exists` for pg_dump command
 * Empty string as HOST for postgres unix domain socket connection is now supported.
 * Support Python 3.13 and Django 5.2


### PR DESCRIPTION
## Description

Allow passing of unlimited options to pg_restore without needing to customise this package every time.   I need this so that i can pass --no-owner to restore postgres data from different environments.

This will supersede the need for the current --no-drop, and --no-owner that passes through to postgres and avoids adding everything postgres supports in this package.

Additionally avoid string concatenation when compiling the command so we can make execution more secure without needing a shell. I didn't want to take the leap and do this though without confirming that was ok/a good direction. :)

## Checklist

Please update this checklist as you complete each item:

-   [x] Tests have been developed for bug fixes or new functionality.
-   [x] The changelog has been updated, if necessary.
-   [x] Documentation has been updated, if necessary.
-   [x] GitHub Issues closed by this PR have been linked.

<sub>By submitting this pull request I agree that all contributions comply with this project's open source license(s).</sub>
